### PR TITLE
Updated dependencies with new maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
     // See https://docs.gradle.org/current/userguide/declaring_repositories.html
     // for more information about repositories.
 	maven { url "https://maven.shedaniel.me/" }
+	maven { url "https://maven.terraformersmc.com/" }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/use
 	minecraft_version=1.16.5
-	yarn_mappings=1.16.5+build.5
-	loader_version=0.11.3
+	yarn_mappings=1.16.5+build.10
+	loader_version=0.11.7
 
 # Mod Properties
 	mod_version = 1.0.0
@@ -14,8 +14,8 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.31.0+1.16
-	
+	fabric_version=0.40.0+1.16
+
 	mod_menu_version=1.14.13+build.19
-	cloth_config_version=4.11.14
+	cloth_config_version=4.11.26
 


### PR DESCRIPTION
Added [terraformersmc's maven](https://maven.terraformersmc.com) for ModMenu.
Updated fabric_version to 0.40.0+1.16
Updated cloth config to 4.11.26
Updated yarn mappings to 1.16.5+build.10
Updated loader to 0.11.7
Signed-off-by: apple <davidalb97@hotmail.com>