### PR TITLE
Declared mod as client only in metadata.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "icon": "assets/chatsounds/icon.png",
 
-  "environment": "*",
+  "environment": "client",
   "entrypoints": {
     "client": [
       "net.chatsounds.Chatsounds"


### PR DESCRIPTION
This changes the environment to only be set to client instead of both. This is consistent with the available entry points right now, which only exist for client and not server.
Closes #16